### PR TITLE
[Feat] 메인화면 AppBar 구현

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({Key? key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: CupertinoColors.systemMint,
+        title: Text(
+          'SynccIT',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: Icon(
+          Icons.menu,
+        ),
+        actions: [
+          IconButton(
+            onPressed: () {},
+            icon: Icon(CupertinoIcons.search),
+          ),
+          IconButton(
+            onPressed: () {},
+            icon: Icon(CupertinoIcons.person),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:syncc_it/home_page.dart';
 
 void main() async {
 
@@ -20,7 +21,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      home: Scaffold(),
+      home: HomePage(),
     );
   }
 }


### PR DESCRIPTION
## 🧵기능 요약 설명(Motivation)
메인화면 AppBar 구현

## 🎯주요 작업 내용(Key Changes)
- main.dart의 MyApp에서 Homepage() 리턴 처리
- home_page.dart의 build 위젯에 AppBar() 구현

## 🙏비고(To Reviewers)
- 상단에서 띄우고 위치 조정하는 작업 추후 진행 예정
- 검색 아이콘을 AppBar 내에 추가하여 클릭 시 하단에 검색바 뜨도록 구현 예정
- 앱바 아이콘 디자인 원하시는대로 변경 가능합니다 @c00kiecream 


